### PR TITLE
Prepended "b" to the wind direction names to make them binary strings

### DIFF
--- a/bin/user/twi.py
+++ b/bin/user/twi.py
@@ -179,6 +179,7 @@ class TWIDriver(weewx.drivers.AbstractDevice):
             'extraTemp1': data.get('temperature_aux'),
             'outHumidity': data.get('humidity'),
             'barometer': data.get('barometer'),
+            'altimeter': data.get('barometer'),
             'rain': calculate_rain(data['rain_total'], self.last_rain)
         }
         self.last_rain = data['rain_total']

--- a/bin/user/twi.py
+++ b/bin/user/twi.py
@@ -48,6 +48,7 @@ from __future__ import with_statement, print_function
 import serial
 import syslog
 import time
+#import pdb
 
 import weewx.drivers
 from weewx.wxformulas import calculate_rain
@@ -273,13 +274,14 @@ class TWIStation(object):
         # 13:28 06/02/16 WSW 00MPH 460F 081F 086F 054% 29.31F 00.00"D 00.00"M 00.00"R
         # 13:28 06/02/16 SW  00MPH 460F 081F 086F 054% 29.31F 00.00"D 00.00"M 00.00"R
         # 13:29 06/02/16 W   00MPH 460F 081F 086F 054% 29.31F 00.00"D 00.00"M 17.15"T
+        # b'04:23 01/29/23 NNW 00MPH 460F 063F 0-4F 094% 29.80R 00.00"D 00.00"M 00.00"T'
         parts = s.split()
         # At least some versions of TWI firmware confuse negative
         # outdoor temperatures, e.g. report '0-20F' instead of '-20F'.
         # Detect and fix them here so conversion to float will work.
-        if parts and parts[6][1] == '-':
+        if parts and parts[6][1:2] == b'-':
             try:
-                parts[6] = '-%s' % parts[6][2:5]
+                parts[6] = parts[6][1:].strip(b'F')
             except IndexError:
                 pass
         data = {

--- a/bin/user/twi.py
+++ b/bin/user/twi.py
@@ -284,7 +284,7 @@ class TWIStation(object):
             try:
                 parts[6] = parts[6][1:].strip(b'F')
             except IndexError:
-                pass
+                loginf("ERROR: flubbed negative temp fix! %s" % parts[6])
         try:
             data = {
                 'time': parts[0],
@@ -301,7 +301,7 @@ class TWIStation(object):
                 'rain_total': TWIStation.try_float(parts[11][:-2])
             }
         except IndexError as err:
-            loginf("ERROR:bad value from station? -- %s %s", (parts, err))
+            loginf("ERROR:bad value from station? -- %s %s" % (parts, err))
 
         return data
 

--- a/bin/user/twi.py
+++ b/bin/user/twi.py
@@ -285,20 +285,24 @@ class TWIStation(object):
                 parts[6] = parts[6][1:].strip(b'F')
             except IndexError:
                 pass
-        data = {
-            'time': parts[0],
-            'date': parts[1],
-            'wind_dir': TWIStation.COMPASS_POINTS.get(parts[2]),
-            'wind_speed': TWIStation.try_float(parts[3][:2]),
-            'temperature_aux': TWIStation.try_float(parts[4][:3]),
-            'temperature_in': TWIStation.try_float(parts[5][:3]),
-            'temperature_out': TWIStation.try_float(parts[6][:3]),
-            'humidity': TWIStation.try_float(parts[7][:3]),
-            'barometer': TWIStation.try_float(parts[8][:-1]),
-            'rain_day': TWIStation.try_float(parts[9][:-2]),
-            'rain_month': TWIStation.try_float(parts[10][:-2]),
-            'rain_total': TWIStation.try_float(parts[11][:-2])
-        }
+        try:
+            data = {
+                'time': parts[0],
+                'date': parts[1],
+                'wind_dir': TWIStation.COMPASS_POINTS.get(parts[2]),
+                'wind_speed': TWIStation.try_float(parts[3][:2]),
+                'temperature_aux': TWIStation.try_float(parts[4][:3]),
+                'temperature_in': TWIStation.try_float(parts[5][:3]),
+                'temperature_out': TWIStation.try_float(parts[6][:3]),
+                'humidity': TWIStation.try_float(parts[7][:3]),
+                'barometer': TWIStation.try_float(parts[8][:-1]),
+                'rain_day': TWIStation.try_float(parts[9][:-2]),
+                'rain_month': TWIStation.try_float(parts[10][:-2]),
+                'rain_total': TWIStation.try_float(parts[11][:-2])
+            }
+        except IndexError as err:
+            loginf("ERROR:bad value from station? -- %s %s", (parts, err))
+
         return data
 
     @staticmethod


### PR DESCRIPTION
because the strings returned from TWI are also binary strings in python3.

Added a try/except block around opening the serial port.

Default to five second polls of the station and prompt during configuration to change that if desired.  Winds around me are very gusty so more frequent samples increases the chances of catching a peak gust.

The station may return barometric *pressure* but I believe most (all?) users will "calibrate" their WR25 console to display the barometer corrected for comparisons against sea level barometric pressure.  In weewx terms, I changed the loop tag from "pressure" to "barometer" to make sensible barometric readings display in the various skins that look for "barometer".  This may not be technically correct but at 8258' elevation, reporting as "pressure" caused weewx to calculate my "barometer" to > 41 inHg!

The WR25 reports a garbled string for below zero outdoor temperatures. Instead of "-20F" it may report "0-20F".  This causes an exception when we try to convert that string to a float.  Added code to reformat the negative temperature if necessary.  I made this change for and published it to wview many years ago.  Recent VERY cold weather allowed me to test it again!